### PR TITLE
Update simple_encryption

### DIFF
--- a/simple_encryption
+++ b/simple_encryption
@@ -10,7 +10,7 @@
 #requires package "quanteda"
 
 simple_encryption <- function(message, key, decode = FALSE){
-  code <- letters[c((1+key):length(letters), 1:key)]
+  code <- letters[c(1+ (key %% length(letters)):length(letters), 1:key)]
   res <- unlist(strsplit(message, " "))
   res <- unlist(strsplit(res, ""))
   res <- tolower(res)


### PR DESCRIPTION
now "key" can have values > length of alphabet and will be "displaced" by the same amount (i.e. key = 30 = 4 because 30-26 = 4)